### PR TITLE
Feature - Implement dry run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,16 @@ The import order of this plugin matters, it is possible that it will not work de
 ### 🔒 Interface Local Multicast
 - **`224.0.0.0/24`**
 
-### 🔒 DenyList
-- Add your entries in the plugin configuration.
+## ⚙️ Parameters
+
+### ✅ Allow List
+- Add domains to bypass rebinding protection.
+
+### 🚫 Deny List
+- Specify entries to block in the plugin configuration.
+
+### 🧪 Dry Run Mode
+- The plugin will only log actions instead of blocking them. Use this parameter to test without enforcing rules.
 
 ---
 
@@ -42,6 +50,7 @@ Keeping the network secure! 🔐
 stopdnsrebind [ZONES...] {
     allow [ZONES...]
     deny [IPNet]
+    dryrun
 }
 ```
 
@@ -56,6 +65,14 @@ To demonstrate the usage of plugin stopdnsrebind, here we provide some typical e
     stopdnsrebind {
         allow internal.example.org
         deny 192.0.2.1/24
+    }
+}
+~~~
+
+~~~ corefile
+. {
+    stopdnsrebind {
+        dryrun
     }
 }
 ~~~

--- a/setup_test.go
+++ b/setup_test.go
@@ -62,6 +62,13 @@ func Test_setup(t *testing.T) {
 			}`,
 			true,
 		},
+		{
+			"enable dry run mode",
+			`stopdnsrebind {
+				dryrun
+			}`,
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/stopdnsrebind.go
+++ b/stopdnsrebind.go
@@ -69,15 +69,16 @@ func (a Stopdnsrebind) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 			// Keeping the network secure!
 		*/
 
-		if a.DryRun {
-			log.Warningf("[DRY RUN] - REFUSED DNAME: [%s] | IPAdrr: [%s]", state.QName(), ip)
-
-			w.WriteMsg(nw.Msg)
-			return 0, nil
-		}
-
 		if !ip.IsGlobalUnicast() || ip.IsInterfaceLocalMulticast() ||
 			ip.IsPrivate() || shouldDeny(ip, a.DenyList) {
+
+			if a.DryRun {
+				log.Warningf("[DRY RUN] - REFUSED DNAME: [%s] | IPAdrr: [%s]", state.QName(), ip)
+
+				w.WriteMsg(nw.Msg)
+				return 0, nil
+			}
+
 			m := new(dns.Msg)
 			m.SetRcode(r, dns.RcodeRefused)
 			w.WriteMsg(m)


### PR DESCRIPTION
Adding new parameter that activates test mode, allowing you to test blocking rules without applying them. In this mode, the plugin will only log what should be blocked.